### PR TITLE
assertion is always true so remove the parentheses

### DIFF
--- a/mmdet/datasets/ytvos.py
+++ b/mmdet/datasets/ytvos.py
@@ -3,6 +3,7 @@ import os.path as osp
 import random
 import mmcv
 from .custom import CustomDataset
+from .extra_aug import ExtraAugmentation
 from .transforms import (ImageTransform, BboxTransform, MaskTransform,
                          Numpy2Tensor)
 from pycocotools.ytvos import YTVOS

--- a/mmdet/models/detectors/base.py
+++ b/mmdet/models/detectors/base.py
@@ -139,7 +139,7 @@ class BaseDetector(nn.Module):
           self.gen_colormask()
         if isinstance(bbox_result, dict) and len(bbox_result.keys()) == 0:
             return
-        assert(len(imgs) == 1, "only support mini-batch size 1") 
+        assert len(imgs) == 1, "only support mini-batch size 1"
         for img, img_meta in zip(imgs, img_metas):
             h, w, _ = img_meta['img_shape']
             #img_show = img[:h, :w, :]


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/youtubevos/MaskTrackRCNN on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./mmdet/models/detectors/base.py:142:9: F631 assertion is always true, perhaps remove parentheses?
        assert(len(imgs) == 1, "only support mini-batch size 1") 
        ^
./mmdet/datasets/ytvos.py:98:30: F821 undefined name 'ExtraAugmentation'
            self.extra_aug = ExtraAugmentation(**extra_aug)
                             ^
1     F631 assertion is always true, perhaps remove parentheses?
1     F821 undefined name 'ExtraAugmentation'
2
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree